### PR TITLE
Doc: replace obsolete 'profile_name' and 'class_name'

### DIFF
--- a/request_format.md
+++ b/request_format.md
@@ -66,7 +66,7 @@ SEAR provides the following standardized JSON schema for issuing security reques
   > A **profile-identifying parameter** is **NOT** allowed for the `"racf-options"` **Admin Type** because **RACF Options** represent a **singleton** configuration with **NO** concept of multiple discrete *"profiles"* that can be created, deleted, or managed.
 
   {: .note }
-  > `"class_name"` **MUST** be used to indicate which **Class Name** the specified **Security Profile** is associated with for the `"resource"` and `"permission"` **Admin Types**.
+  > `"class"` **MUST** be used to indicate which **Class Name** the specified **Security Profile** is associated with for the `"resource"` and `"permission"` **Admin Types**.
 
   &nbsp;
 
@@ -80,13 +80,13 @@ SEAR provides the following standardized JSON schema for issuing security reques
 
   &nbsp;
 
-* `"class_name"`<br>
+* `"class"`<br>
   A `string` value identifying a **Class Name** that the specified **Security Profile** is associated with.
 
   &nbsp;
 
   {: .note }
-  > `"class_name"` is **required** for and **only** allowed for the `"resource"` and `"permission"` **Admin Types**.
+  > `"class"` is **required** for and **only** allowed for the `"resource"` and `"permission"` **Admin Types**.
 
   &nbsp;
 
@@ -99,7 +99,7 @@ SEAR provides the following standardized JSON schema for issuing security reques
   > Only the `"dataset"` and `"permission"` **Admin Types** can be used with `"volume"`, and **only** for `"add"`, `"alter"`, and `"delete"` **Operations**.
 
   {: .note }
-  > _Note that for the `"permission"` **Admin Type**, this parameter will only take effect if the `"class_name"` parameter is set to `"DATASET"`.
+  > _Note that for the `"permission"` **Admin Type**, this parameter will only take effect if it has the parameter `"dataset"`.
 
   &nbsp;
 
@@ -112,7 +112,7 @@ SEAR provides the following standardized JSON schema for issuing security reques
   > Only the `"dataset"` and `"permission"` **Admin Types** can be used with `"generic"`, and **only** for `"add"`, `"alter"`, and `"delete"` **Operations**.
 
   {: .note }
-  > Note that for the `"permission"` **Admin Type**, this parameter will only take effect if the `"class_name"` parameter is set to `"DATASET"`.
+  > Note that for the `"permission"` **Admin Type**, this parameter will only take effect if it has the parameter `"dataset"`.
 
   {: .note }
   > `"generic"` may **only** be set to `"yes"` or `"no"`.

--- a/request_format.md
+++ b/request_format.md
@@ -48,12 +48,12 @@ SEAR provides the following standardized JSON schema for issuing security reques
   | `"permission"` | Used for **Permission** administration. |
   | `"keyring"` | Used for **Keyring** administration. |
 
-* Identifying parameter: `"userid"`, `"group"`, `"dataset"`, `"resource"` or `"keyring"` <br>
+* `"userid"`, `"group"`, `"dataset"`, `"resource"` or `"keyring"` <br>
   A `string` value identifying a **Security Profile** to **Add**, **Alter**, **Extract**, or **Delete**.
   
   The specific parameter used depends on the **Admin Type**:
 
-  | **Identifying parameter** | **Admin Type** |
+  | **Identifier** | **Admin Type** |
   | `"userid"` | `"user"` |
   | `"group"` | `"group"` |
   | `"dataset"` | `"dataset"` |

--- a/request_format.md
+++ b/request_format.md
@@ -46,14 +46,24 @@ SEAR provides the following standardized JSON schema for issuing security reques
   | `"dataset"` | Used for **Data Set** administration. |
   | `"racf-options"` | Used for **RACF Options** administration. |
   | `"permission"` | Used for **Permission** administration. |
+  | `"keyring"` | Used for **Keyring** administration. |
 
-* `"profile_name"`<br>
+* Identifying parameter: `"userid"`, `"group"`, `"dataset"`, `"resource"` or `"keyring"` <br>
   A `string` value identifying a **Security Profile** to **Add**, **Alter**, **Extract**, or **Delete**.
+  
+  The specific parameter used depends on the **Admin Type**:
 
+  | **Identifying parameter** | **Admin Type** |
+  | `"userid"` | `"user"` |
+  | `"group"` | `"group"` |
+  | `"dataset"` | `"dataset"` |
+  | `"resource"` | `"resource"` |
+  | `"keyring"` | `"keyring"` |
+  
   &nbsp;
 
   {: .note }
-  > `"profile_name"` is **NOT** allowed to be used with the `"racf-options"` **Admin Type** due to **RACF Options** being a **Singleton** for which there is **NO** concept of multiple discrete "profiles" that can be created, deleted, and managed.
+  > A **profile-identifying parameter** is **NOT** allowed for the `"racf-options"` **Admin Type** because **RACF Options** represent a **singleton** configuration with **NO** concept of multiple discrete *"profiles"* that can be created, deleted, or managed.
 
   {: .note }
   > `"class_name"` **MUST** be used to indicate which **Class Name** the specified **Security Profile** is associated with for the `"resource"` and `"permission"` **Admin Types**.
@@ -136,7 +146,7 @@ The following **SEAR Request JSON** creates new new **RACF Userid** called `ERIP
 {
   "operation": "add",
   "admin_type": "user",
-  "profile_name": "ERIPLEY",
+  "userid": "ERIPLEY",
   "traits": {
     "base:name": "Ellen Ripley",
     "omvs:uid": 24,
@@ -153,7 +163,7 @@ The following **SEAR Request JSON** alters an existing **RACF Userid** called `E
 {
   "operation": "alter",
   "admin_type": "user",
-  "profile_name": "ESATTLER",
+  "userid": "ESATTLER",
   "traits": {
     "base:name": "Ellie Sattler"
   }
@@ -168,7 +178,7 @@ The following **SEAR Request JSON** deletes an existing **RACF Userid** called `
 {
   "operation": "delete",
   "admin_type": "user",
-  "profile_name": "MRAINES"
+  "userid": "MRAINES"
 }
 ```
 
@@ -180,6 +190,6 @@ The following **SEAR Request JSON** extracts the **Profile Data** for a **RACF U
 {
   "operation": "extract",
   "admin_type": "user",
-  "profile_name": "CDEARING"
+  "userid": "CDEARING"
 }
 ```

--- a/result_format.md
+++ b/result_format.md
@@ -39,7 +39,11 @@ SEAR provides the following standardized JSON schema for security results return
 &nbsp;
 
 * `"profile"`<br>
-  An `object` describing **Profile Data** extracted as a result of an `"extract"` **Operation**. This structure contains all of the **Profile Data** that corresponds to the profile specified using the `"profile_name"` **Parameter** *(and the `"class_name"` **Parameter** for **Admin Types** that require it)* of the corresponding request. The only exception is the `"racf-options"` **Admin Type**, where `"profile_name"` is **NOT** allowed in **RACF Options Administration** requests due to **RACF Options** being a **Singleton** for which there is **NO** concept of multiple discrete *"profiles"* that can be created, deleted, and managed.
+  An `object` describing **Profile Data** extracted as a result of an `"extract"` **Operation**. This structure contains all of the **Profile Data** that corresponds to the profile specified using the appropriate identifying **Parameter** of the corresponding request — `"userid"` for **User** type, `"group"` for **Group** type, `"dataset"` for **Dataset** type, `"resource"` for **Resource** type, and `"keyring"` for **Keyring** type (and the `"class"` **Parameter** for **Admin Types** that require it).
+
+  The `"racf-options"` **Admin Type** does **not** use a profile-identifying parameter because **RACF Options** represent a **singleton configuration** with no concept of multiple discrete *"profiles"* that can be created, deleted, or managed.
+
+  The `"racf-rrsf"` **Admin Type** also does **not** use a profile-identifying parameter and supports only extraction of **all RRSF options**. The **RACF Remote Sharing Facility (RRSF)** represents a network of *"RRSF nodes"*, where a node may consist of **either** a single z/OS system with its own RACF database **or** multiple z/OS systems sharing a RACF database.
 
   * `"<segment>"`<br>
     An `object` describing a **RACF Segment**. At least one **Segment** will be returned, and each **Segment** returned will contain one or more **Traits**.


### PR DESCRIPTION
This PR updates the documentation to remove references to the obsolete parameters `profile_name` and `class_name`. These have been replaced with more specific identifying parameters and the class attribute to align with the current version.

🛠 **Changes Made**
**Parameter Cleanup**: Replaced all instances of the deprecated `profile_name` with the appropriate context-specific identifiers: `userid, group, dataset, resource, and keyring`.

**Schema Alignment**: Updated `class_name` to `class` throughout the documentation to ensure consistency with the current version.

**Logic Refinement**: Updated documentation to reflect that validation no longer relies on checking if `class_name` is set to `"DATASET"` Instead, validation is performed by checking if the request parameters actually contain the `dataset` field.

Closes #13 