### PR TITLE
Added 0.6.0 to the Python support table

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -50,6 +50,7 @@ You can acquire Python from your z/OS install as bypassable requisite or grab it
 
 | SEAR version | Py 3.12     | Py 3.13     | Py 3.14     |
 |--------------|-------------|-------------|-------------|
+| 0.6.x        |   ✅        |    ✅       |    ✅       |
 | 0.5.x        |   ✅        |    ✅       |    ✅       |
 | 0.4.0        |   ✅        |    ✅       |    ❌       |
 | 0.3.1        |   ✅        |    ✅       |    ❌       |


### PR DESCRIPTION
Added 0.6.0 to the Python support table, in preparation for SEAR 0.6.0